### PR TITLE
Add a Decimal type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.python-version


### PR DESCRIPTION
A follow up to #1. In that PR `ValueCode.amount` was changed to be specified as a `str` because that's how it serializes. However that's not convenient because then you're unable to write things like `ValueCode(amount=1.23)` or so on. This follow up PR adds an `Decimal` that allows deserializing from a str, float, int, and `decimal.Decimal` (the Python built in) but always serializes as a `str`.