### PR TITLE
MedicareSource: switch to MultiValueEnum and add alias for Inpatient

### DIFF
--- a/mphapi/pricing.py
+++ b/mphapi/pricing.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from aenum import MultiValueEnum 
 from typing import Annotated, Optional
 
 from pydantic import BaseModel, Field
@@ -52,7 +53,7 @@ class RuralIndicator(str, Enum):
     URBAN = ""
 
 
-class MedicareSource(str, Enum):
+class MedicareSource(str, MultiValueEnum):
     Ambulance = "AmbulanceFS"
     Anesthesia = "AnesthesiaFS"
     CriticalAccessHospital = "CAH pricer"
@@ -65,7 +66,7 @@ class MedicareSource(str, Enum):
     EstimateByStateCode = "StateCode"
     EstimateByStateOnly = "StateOnly"
     EstimateByUnknown = "Unknown"
-    Inpatient = "IPPS"
+    Inpatient = "IPPS", "Inpatient pricer"
     Labs = "LabsFS"
     MPFS = "MPFS"
     Outpatient = "Outpatient pricer"


### PR DESCRIPTION
The header‑level MedicareSource field can occasionally receive the value “Inpatient pricer” instead of “IPPS”. 
The alias “Inpatient pricer” was added into class, assuming that both mean the same thing.
Please let me know if this is wrong.

Yasin